### PR TITLE
Fix update status router

### DIFF
--- a/routes/stores.js
+++ b/routes/stores.js
@@ -154,7 +154,7 @@ router.patch("/updateStatus/:idStore", authSystemAdmin, async (req, res) => {
     if (status === "active" && user.role != "system_admin") {
       let data = await UserModel.updateOne(
         { _id: user._id },
-        { role: "store_admin" }
+        { role: "admin" }
       );
       console.log(data);
     } else {

--- a/routes/users.js
+++ b/routes/users.js
@@ -19,8 +19,6 @@ router.get("/", (req, res) => {
   res.json({ msg: "Users work" });
 });
 
-// open("https://www.wikipedia.org/")
-
 // all users
 router.get("/usersList", authSystemAdmin, async (req, res) => {
   let perPage = req.query.perPage || 10;


### PR DESCRIPTION
fix updateStatus router in stores 
if user is not system_admin the the role is changed to store_admin instead of admin